### PR TITLE
Expand glob pattern support for CLI and HubBuilder input files

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -12,7 +12,7 @@ tracknado design -i tracks/*.bw -o tracks.csv
 
 | Option | Meaning |
 | --- | --- |
-| `-i`, `--input-files` | One or more track files. Repeat the option to add another set. |
+| `-i`, `--input-files` | One or more track files or glob patterns (for example, `'tracks/*.bw'`). Repeat the option to add another set. Quote glob patterns to let TrackNado expand them, including recursive `**` patterns. |
 | `-o`, `--output` | CSV or TSV path to write. |
 | `--seqnado` | Extract fields from a seqnado-style directory layout. |
 | `--grouping-regex` | Extract named groups from file names. |
@@ -27,7 +27,7 @@ tracknado create --metadata tracks.csv --output my_hub --genome-name hg38
 
 | Option | Meaning |
 | --- | --- |
-| `-i`, `--input-files` | Track files to include. Use this instead of `--metadata` when no table is needed. |
+| `-i`, `--input-files` | Track files or glob patterns to include. Quote patterns such as `'tracks/**/*.bigWig'` to let TrackNado expand them. Use this instead of `--metadata` when no table is needed. |
 | `-m`, `--metadata` | CSV or TSV with a `file_path` column. |
 | `-o`, `--output` | Staged hub directory. Required unless creating a template. |
 | `-t`, `--template` | Write a header-only metadata template and exit. |

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -9,6 +9,24 @@ def test_builder_add_tracks(sample_bigwig):
     assert len(builder.tracks) == 1
     assert builder.tracks[0].metadata["antibody"] == "CTCF"
 
+
+def test_builder_add_tracks_expands_glob_patterns(tmp_dir):
+    tracks_dir = tmp_dir / "tracks"
+    tracks_dir.mkdir()
+    first = tracks_dir / "a.bigWig"
+    second = tracks_dir / "b.bigWig"
+    first.touch()
+    second.touch()
+
+    builder = HubBuilder().add_tracks([str(tracks_dir / "*.bigWig")])
+
+    assert [track.path for track in builder.tracks] == [first, second]
+
+
+def test_builder_add_tracks_rejects_unmatched_glob(tmp_dir):
+    with pytest.raises(ValueError, match="No files matched glob pattern"):
+        HubBuilder().add_tracks([str(tmp_dir / "*.bigWig")])
+
 def test_builder_from_df(tmp_dir):
     df = pd.DataFrame([
         {"file_path": str(tmp_dir / "f1.bw"), "cell": "K562"},

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -126,3 +126,23 @@ def test_cli_design_generates_editable_metadata_table(tmp_dir):
     for col in ["color", "supertrack", "composite", "overlay"]:
         assert col in df.columns
     assert "path" not in df.columns
+
+
+def test_cli_design_expands_quoted_glob_pattern(tmp_dir):
+    tracks_dir = tmp_dir / "tracks"
+    tracks_dir.mkdir()
+    (tracks_dir / "k562_ctcf.bw").touch()
+    (tracks_dir / "peaks.bb").touch()
+    output = tmp_dir / "tracks.csv"
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["design", "-i", str(tracks_dir / "*"), "-o", str(output)],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert list(pd.read_csv(output)["file_path"]) == [
+        str(tracks_dir / "k562_ctcf.bw"),
+        str(tracks_dir / "peaks.bb"),
+    ]

--- a/tracknado/builder.py
+++ b/tracknado/builder.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import glob
 import pathlib
 from typing import Callable, Any, Optional, Union
 import pandas as pd
@@ -44,10 +45,24 @@ class HubBuilder(BaseModel):
     def add_tracks(
         self, paths: list[str] | list[pathlib.Path], **common_metadata: str
     ) -> HubBuilder:
-        """Add multiple tracks from paths."""
+        """Add multiple tracks from paths or glob patterns.
+
+        Glob patterns are expanded before tracks are added, including recursive
+        patterns such as ``tracks/**/*.bigWig``.  A pattern that matches no
+        files raises an error instead of being treated as a literal path.
+        """
         for p in paths:
-            path = pathlib.Path(p)
-            self.tracks.append(Track(path=path, metadata=common_metadata.copy()))
+            pattern = str(p)
+            matches = sorted(glob.glob(pattern, recursive=True))
+            if glob.has_magic(pattern):
+                if not matches:
+                    raise ValueError(f"No files matched glob pattern: {pattern}")
+                track_paths = (pathlib.Path(match) for match in matches)
+            else:
+                track_paths = (pathlib.Path(p),)
+
+            for path in track_paths:
+                self.tracks.append(Track(path=path, metadata=common_metadata.copy()))
         return self
 
     def add_tracks_from_df(

--- a/tracknado/cli.py
+++ b/tracknado/cli.py
@@ -14,7 +14,7 @@ console = Console()
 @app.command()
 def create(
     input_files: Optional[List[pathlib.Path]] = typer.Option(
-        None, "--input-files", "-i", help="A list of local track files (bigWig, bigBed, BAM, etc.) to include in the hub."
+        None, "--input-files", "-i", help="Local track files or glob patterns (for example, 'tracks/*.bigWig') to include in the hub."
     ),
     output: Optional[pathlib.Path] = typer.Option(
         None, "--output", "-o", help="The directory where the staged hub and tracknado_config.json will be created."
@@ -141,7 +141,7 @@ def create(
 @app.command()
 def design(
     input_files: List[pathlib.Path] = typer.Option(
-        ..., "--input-files", "-i", help="Track files (bigWig, bigBed, BAM, etc.) to generate a metadata table for."
+        ..., "--input-files", "-i", help="Track files or glob patterns (for example, 'tracks/*.bigWig') for the metadata table."
     ),
     output: pathlib.Path = typer.Option(
         ..., "--output", "-o", help="Path to write the editable metadata CSV/TSV to."
@@ -279,7 +279,6 @@ def cli():
 
 if __name__ == "__main__":
     app()
-
 
 
 


### PR DESCRIPTION
This pull request adds support for glob pattern expansion when specifying track files in both the CLI and Python API. Now, users can provide glob patterns (including recursive patterns like `tracks/**/*.bigWig`) to select multiple files at once, improving usability and flexibility. The documentation, CLI help messages, and tests have all been updated to reflect and validate this new behavior.

**Glob pattern support and API changes:**

* Updated the `HubBuilder.add_tracks` method to accept glob patterns, expanding them to matching files and raising an error if no files are matched.
* Updated CLI option help messages for both `design` and `create` commands to document support for glob patterns. [[1]](diffhunk://#diff-276cb36c5939e4fd71b99227e011ac96ed1d19926947ca63b9f59c0c355e0a7eL17-R17) [[2]](diffhunk://#diff-276cb36c5939e4fd71b99227e011ac96ed1d19926947ca63b9f59c0c355e0a7eL144-R144)

**Documentation updates:**

* Improved documentation in `docs/reference/cli.md` to explain glob pattern usage and the need to quote patterns in the shell. [[1]](diffhunk://#diff-975000db2bb150ebdc1a762c178c531c19747c5c75a8147bec4a31e69945e711L15-R15) [[2]](diffhunk://#diff-975000db2bb150ebdc1a762c178c531c19747c5c75a8147bec4a31e69945e711L30-R30)

**Testing improvements:**

* Added tests to verify that glob patterns are properly expanded, unmatched patterns raise errors, and CLI commands correctly process glob patterns. [[1]](diffhunk://#diff-dcfe6b9ffa9797a45d099987427f0f8039f07988f6d068aa554f079e08e99adcR12-R29) [[2]](diffhunk://#diff-4e8715c7a425ee52e74b7df4d34efd32e8c92f3e60bd51bc2e1ad5943b82032eR129-R148)

**Other code changes:**

* Imported the `glob` module in `tracknado/builder.py` to support pattern expansion.