### PR TITLE
Add configurable hosting profiles

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -141,6 +141,22 @@ TrackNado prints:
 https://tracks.example.org/public/researcher/chipseq/experiment-2025-09-29/example_hub.hub.txt
 ```
 
+To save that URL to a text file for a workflow or to share it later, add
+`--hub-url-file`:
+
+```bash
+tracknado create \
+  --metadata tracks.csv \
+  --output /shared/track-hubs/researcher/chipseq/experiment-2025-09-29 \
+  --hub-name example_hub \
+  --genome-name hg38 \
+  --hosting example_web \
+  --hub-url-file hub_url.txt
+```
+
+This creates `hub_url.txt` in the current directory containing only the public
+hub URL. The directory containing the file must already exist.
+
 You can define more than one profile in the same file by adding another
 `[hosting.name]` section, then select it with `--hosting name`. Use
 `--hosting-config path/to/hosting.toml` if the profile file needs to live in a

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -70,6 +70,83 @@ In the UCSC Genome Browser, open **My Data → Track Hubs**, then enter the publ
 https://example.org/path/to/my_hub/project_tracks.hub.txt
 ```
 
+### Print the URL with a hosting profile (optional)
+
+If your group has a web-published storage area, you can set up a hosting profile
+once. TrackNado then prints the correct hub URL whenever you build into that
+area. The profile is personal: it is not shared with TrackNado users on other
+HPCs or web servers.
+
+#### Create your profile file
+
+On the command line, run:
+
+```bash
+mkdir -p ~/.config/tracknado
+nano ~/.config/tracknado/hosting.toml
+```
+
+The second command opens a new text file. Paste the following example, replacing
+the values only if your local HPC and public web locations differ:
+
+```toml
+[hosting.example_web]
+local_root = "/shared/track-hubs"
+public_root = "https://tracks.example.org/public"
+```
+
+In `nano`, save with **Ctrl+O**, press **Enter** to accept the filename, then
+exit with **Ctrl+X**. Do not put a trailing `/` at the end of either value.
+
+#### Choose the two roots
+
+`local_root` is the shared beginning of the HPC paths where you publish hubs.
+`public_root` is the matching beginning of their public URLs. Choose them so the
+remaining part of a path is identical in both places.
+
+For example, an output directory and its public directory are:
+
+```text
+HPC output:   /shared/track-hubs/researcher/chipseq/experiment-2025-09-29
+Public path:  https://tracks.example.org/public/researcher/chipseq/experiment-2025-09-29
+```
+
+The part that changes is the root:
+
+```text
+/shared/track-hubs
+https://tracks.example.org/public
+```
+
+Everything after those roots (`researcher/chipseq/experiment-2025-09-29`) stays
+the same. If you do not know the public URL corresponding to a directory, ask
+your HPC or web-service administrator before creating the profile.
+
+#### Use the profile
+
+Build your hub as usual, adding `--hosting example_web`:
+
+```bash
+tracknado create \
+  --metadata tracks.csv \
+  --output /shared/track-hubs/researcher/chipseq/experiment-2025-09-29 \
+  --hub-name example_hub \
+  --genome-name hg38 \
+  --hosting example_web
+```
+
+TrackNado prints:
+
+```text
+https://tracks.example.org/public/researcher/chipseq/experiment-2025-09-29/example_hub.hub.txt
+```
+
+You can define more than one profile in the same file by adding another
+`[hosting.name]` section, then select it with `--hosting name`. Use
+`--hosting-config path/to/hosting.toml` if the profile file needs to live in a
+project or shared location. Without `--hosting`, TrackNado stages the hub
+normally and does not attempt to guess its public URL.
+
 ## Build the same hub from Python
 
 ```python

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -51,6 +51,7 @@ tracknado create --metadata tracks.csv --output my_hub --genome-name hg38
 | `--remove-existing` | Remove the existing output directory before staging. |
 | `--hosting` | Name of a user-defined TOML hosting profile used to report the public hub URL. |
 | `--hosting-config` | Optional path to the TOML hosting-profile file. Defaults to `~/.config/tracknado/hosting.toml` (or `$XDG_CONFIG_HOME/tracknado/hosting.toml`). |
+| `--hub-url-file` | Write the resolved public hub URL to a text file. Requires `--hosting`. |
 
 ## `tracknado merge`
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -49,7 +49,8 @@ tracknado create --metadata tracks.csv --output my_hub --genome-name hg38
 | `--description` | HTML file to include as the hub landing page. |
 | `--sort-metadata` | Sort non-standard metadata columns in the saved configuration. |
 | `--remove-existing` | Remove the existing output directory before staging. |
-| `--url-prefix` | Base URL printed with the successful build message; it does not upload files. |
+| `--hosting` | Name of a user-defined TOML hosting profile used to report the public hub URL. |
+| `--hosting-config` | Optional path to the TOML hosting-profile file. Defaults to `~/.config/tracknado/hosting.toml` (or `$XDG_CONFIG_HOME/tracknado/hosting.toml`). |
 
 ## `tracknado merge`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "loguru==0.7.3",
     "pydantic>=2.0",
     "pandera==0.32.1",
+    "tomli>=2.0; python_version < '3.11'",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -97,6 +97,56 @@ def test_cli_create_delegates_to_shared_builder_helper(monkeypatch, tmp_dir):
     assert captured["stage_hub"] is False
 
 
+def test_cli_create_writes_resolved_hub_url_to_file(monkeypatch, tmp_dir):
+    input_file = tmp_dir / "sample.bigWig"
+    input_file.touch()
+    output_dir = tmp_dir / "published-hubs" / "researcher" / "hub"
+    config = tmp_dir / "hosting.toml"
+    config.write_text(
+        "[hosting.site]\n"
+        f'local_root = "{tmp_dir / "published-hubs"}"\n'
+        'public_root = "https://tracks.example.org/public"\n'
+    )
+    url_file = tmp_dir / "hub_url.txt"
+
+    class DummyHub:
+        def stage_hub(self, remove_existing=False):
+            pass
+
+    class DummyBuilder:
+        def build(self, **kwargs):
+            return DummyHub()
+
+    monkeypatch.setattr(
+        "tracknado.cli.tn.configure_builder_from_inputs",
+        lambda **kwargs: DummyBuilder(),
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "create", "-i", str(input_file), "-o", str(output_dir),
+            "--hub-name", "example_hub", "--hosting", "site",
+            "--hosting-config", str(config), "--hub-url-file", str(url_file),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert url_file.read_text() == (
+        "https://tracks.example.org/public/researcher/hub/example_hub.hub.txt\n"
+    )
+
+
+def test_cli_create_rejects_hub_url_file_without_hosting(tmp_dir):
+    result = CliRunner().invoke(
+        app,
+        ["create", "-o", str(tmp_dir / "hub"), "--hub-url-file", str(tmp_dir / "url.txt")],
+    )
+
+    assert result.exit_code == 1
+    assert "requires '--hosting'" in result.output
+
+
 def test_cli_design_generates_editable_metadata_table(tmp_dir):
     track_a = tmp_dir / "k562_ctcf.bw"
     track_b = tmp_dir / "peaks.bb"

--- a/tests/test_hosting.py
+++ b/tests/test_hosting.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+
+import pytest
+
+from tracknado.hosting import hub_url_from_profile
+
+
+def test_hub_url_from_profile_maps_output_relative_to_local_root(tmp_dir):
+    local_root = tmp_dir / "published-hubs"
+    output = local_root / "researcher" / "chipseq" / "hub directory"
+    output.mkdir(parents=True)
+    config = tmp_dir / "hosting.toml"
+    config.write_text(
+        "[hosting.site]\n"
+        f'local_root = "{local_root}"\n'
+        'public_root = "https://example.org/public"\n'
+    )
+
+    assert hub_url_from_profile(output, "PRJNA 317349", "site", config) == (
+        "https://example.org/public/researcher/chipseq/hub%20directory/"
+        "PRJNA%20317349.hub.txt"
+    )
+
+
+def test_hub_url_from_profile_rejects_output_outside_local_root(tmp_dir):
+    local_root = tmp_dir / "published-hubs"
+    local_root.mkdir()
+    config = tmp_dir / "hosting.toml"
+    config.write_text(
+        "[hosting.site]\n"
+        f'local_root = "{local_root}"\n'
+        'public_root = "https://example.org/public/project"\n'
+    )
+
+    with pytest.raises(ValueError, match="not inside"):
+        hub_url_from_profile(tmp_dir / "elsewhere", "hub", "site", config)

--- a/tracknado/cli.py
+++ b/tracknado/cli.py
@@ -56,6 +56,9 @@ def create(
     hosting_config: Optional[pathlib.Path] = typer.Option(
         None, "--hosting-config", help="Path to a TOML hosting-profile configuration file."
     ),
+    hub_url_file: Optional[pathlib.Path] = typer.Option(
+        None, "--hub-url-file", help="Write the resolved public hub URL to this file (requires --hosting)."
+    ),
     convert: bool = typer.Option(
         False, "--convert", help="Enable automatic conversion of formats like BED -> bigBed or GTF -> bigGenePred."
     ),
@@ -96,6 +99,9 @@ def create(
 
     if not output:
         console.print("[red]Error: Missing option '--output' / '-o'.[/red]")
+        raise typer.Exit(code=1)
+    if hub_url_file and not hosting:
+        console.print("[red]Error: '--hub-url-file' requires '--hosting'.[/red]")
         raise typer.Exit(code=1)
 
     logger.info("Initializing TrackNado")
@@ -146,6 +152,16 @@ def create(
             console.print(f"[yellow]Hub created, but no URL was reported: {exc}[/yellow]")
         else:
             logger.info(f"Hub URL: {hub_url}")
+            if hub_url_file:
+                try:
+                    hub_url_file.expanduser().write_text(f"{hub_url}\n")
+                except OSError as exc:
+                    console.print(
+                        f"[yellow]Hub created, but the URL could not be written to "
+                        f"{hub_url_file}: {exc}[/yellow]"
+                    )
+                else:
+                    logger.info(f"Hub URL written to {hub_url_file}")
 
 @app.command()
 def design(
@@ -288,7 +304,6 @@ def cli():
 
 if __name__ == "__main__":
     app()
-
 
 
 

--- a/tracknado/cli.py
+++ b/tracknado/cli.py
@@ -7,6 +7,7 @@ import typer
 from rich.console import Console
 
 import tracknado as tn
+from .hosting import hub_url_from_profile
 
 app = typer.Typer(help="Build and validate UCSC Genome Browser track hubs.")
 console = Console()
@@ -49,8 +50,11 @@ def create(
     overlay_by: Optional[List[str]] = typer.Option(
         None, "--overlay-by", help="Metadata columns to define OverlayTracks (e.g., multi-signal plots)."
     ),
-    url_prefix: str = typer.Option(
-        "https://userweb.molbiol.ox.ac.uk", "--url-prefix", help="Base URL where the hub will be hosted (used for final URL reporting)."
+    hosting: Optional[str] = typer.Option(
+        None, "--hosting", help="Name of a user-defined hosting profile used to report the hub URL."
+    ),
+    hosting_config: Optional[pathlib.Path] = typer.Option(
+        None, "--hosting-config", help="Path to a TOML hosting-profile configuration file."
     ),
     convert: bool = typer.Option(
         False, "--convert", help="Enable automatic conversion of formats like BED -> bigBed or GTF -> bigGenePred."
@@ -135,8 +139,13 @@ def create(
     hub.stage_hub(remove_existing=remove_existing)
     
     logger.info(f"Hub created successfully at {output}")
-    hub_url = f"{url_prefix.strip('/')}/{str(output).strip('/')}/{hub_name}.hub.txt"
-    logger.info(f"Hub URL: {hub_url}")
+    if hosting:
+        try:
+            hub_url = hub_url_from_profile(output, hub_name, hosting, hosting_config)
+        except ValueError as exc:
+            console.print(f"[yellow]Hub created, but no URL was reported: {exc}[/yellow]")
+        else:
+            logger.info(f"Hub URL: {hub_url}")
 
 @app.command()
 def design(
@@ -279,7 +288,6 @@ def cli():
 
 if __name__ == "__main__":
     app()
-
 
 
 

--- a/tracknado/hosting.py
+++ b/tracknado/hosting.py
@@ -1,0 +1,67 @@
+"""Resolve published track-hub URLs from user-defined hosting profiles."""
+
+from __future__ import annotations
+
+import os
+import pathlib
+from urllib.parse import quote
+
+try:  # Python 3.11+
+    import tomllib
+except ModuleNotFoundError:  # Python 3.10
+    import tomli as tomllib
+
+
+def default_hosting_config_path() -> pathlib.Path:
+    """Return the per-user configuration location without requiring it to exist."""
+    config_home = os.environ.get("XDG_CONFIG_HOME")
+    if config_home:
+        return pathlib.Path(config_home) / "tracknado" / "hosting.toml"
+    return pathlib.Path.home() / ".config" / "tracknado" / "hosting.toml"
+
+
+def hub_url_from_profile(
+    output: pathlib.Path,
+    hub_name: str,
+    profile_name: str,
+    config_path: pathlib.Path | None = None,
+) -> str:
+    """Build a hub URL using a ``[hosting.<name>]`` TOML profile.
+
+    A profile maps a local directory tree to its externally visible URL tree.
+    ``output`` must be inside the configured ``local_root``.
+    """
+    config_path = (config_path or default_hosting_config_path()).expanduser()
+    if not config_path.is_file():
+        raise ValueError(f"Hosting configuration not found: {config_path}")
+
+    try:
+        with config_path.open("rb") as config_file:
+            config = tomllib.load(config_file)
+    except tomllib.TOMLDecodeError as exc:
+        raise ValueError(f"Invalid TOML in hosting configuration {config_path}: {exc}") from exc
+
+    profile = config.get("hosting", {}).get(profile_name)
+    if not isinstance(profile, dict):
+        raise ValueError(f"No hosting profile named {profile_name!r} in {config_path}")
+
+    local_root = profile.get("local_root")
+    public_root = profile.get("public_root")
+    if not isinstance(local_root, str) or not isinstance(public_root, str):
+        raise ValueError(
+            f"Hosting profile {profile_name!r} must define string local_root and public_root values"
+        )
+
+    output_path = output.expanduser().resolve()
+    root_path = pathlib.Path(local_root).expanduser().resolve()
+    try:
+        relative_path = output_path.relative_to(root_path)
+    except ValueError as exc:
+        raise ValueError(
+            f"Output directory {output_path} is not inside profile {profile_name!r}'s "
+            f"local_root ({root_path})"
+        ) from exc
+
+    public_path = "/".join(quote(part, safe="") for part in relative_path.parts)
+    hub_file = quote(f"{hub_name}.hub.txt", safe="")
+    return f"{public_root.rstrip('/')}/{public_path}/{hub_file}"


### PR DESCRIPTION
This pull request adds support for user-defined hosting profiles to make it easier to generate the correct public URL for a track hub after building it. Instead of manually specifying a URL prefix, users can now define a TOML profile mapping local directories to their corresponding public URLs. The CLI and documentation have been updated to reflect this new workflow. Additionally, the codebase now supports TOML parsing for Python versions below 3.11 and includes new tests for the hosting logic.

**New hosting profile feature:**

* Added `tracknado/hosting.py`, which introduces the `hub_url_from_profile` function and logic for resolving published hub URLs from user-defined TOML hosting profiles. This includes support for both Python 3.11+ and 3.10 TOML parsing.
* Updated the CLI (`tracknado/cli.py`) to add `--hosting` and `--hosting-config` options, replacing the old `--url-prefix` option. The CLI now uses hosting profiles to print the correct public hub URL after building. [[1]](diffhunk://#diff-276cb36c5939e4fd71b99227e011ac96ed1d19926947ca63b9f59c0c355e0a7eL52-R57) [[2]](diffhunk://#diff-276cb36c5939e4fd71b99227e011ac96ed1d19926947ca63b9f59c0c355e0a7eL138-R147) [[3]](diffhunk://#diff-276cb36c5939e4fd71b99227e011ac96ed1d19926947ca63b9f59c0c355e0a7eR10)

**Documentation updates:**

* Updated the user guide (`docs/guide/getting-started.md`) to describe how to create and use hosting profiles for publishing hubs, with step-by-step instructions and examples.
* Updated the CLI reference (`docs/reference/cli.md`) to document the new `--hosting` and `--hosting-config` options.

**Dependency and testing improvements:**

* Added `tomli` as a dependency for TOML parsing on Python <3.11 in `pyproject.toml`.
* Added tests for the new hosting profile logic in `tests/test_hosting.py`, covering both correct mapping and error cases.